### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,13 @@ RUN yum install -y devtoolset-3
 RUN scl enable devtoolset-3 bash
 RUN printf "\nsource scl_source enable devtoolset-3\n" >> /root/.bashrc
 RUN printf "\nsource scl_source enable devtoolset-3\n" >> /home/$BUILD_USER/.bashrc
-RUN yum install -y cmake3
+
 RUN mv /usr/bin/cmake /usr/bin/cmake2
 RUN mv /usr/bin/ccmake /usr/bin/ccmake2
-RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
-RUN ln -s /usr/bin/ccmake3 /usr/bin/ccmake
+RUN wget https://cmake.org/files/v3.12/cmake-3.12.0-Linux-x86_64.tar.gz -O /tmp/cmake-3.12.0-Linux-x86_64.tar.gz
+RUN cd /usr/local/bin && \
+	tar -xzf /tmp/cmake-3.12.0-Linux-x86_64.tar.gz
+RUN ln -s /usr/local/bin/cmake-3.12.0-Linux-x86_64/bin/cmake /usr/bin/cmake
 
 # Install jboss
 RUN wget http://sourceforge.net/projects/jboss/files/JBoss/JBoss-5.1.0.GA/jboss-5.1.0.GA.zip/download -O /tmp/jboss-5.1.0.GA.zip


### PR DESCRIPTION
Unfortunately, the yum install of cmake is not up to date and does not support some newer cmake functions. This is update to the latest stable release (3.12)